### PR TITLE
Update setup.py to expose scripts/* as CLI entrypoints.

### DIFF
--- a/scripts/create_db.py
+++ b/scripts/create_db.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import gffutils
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 import setuptools
+from glob import glob
+from os.path import dirname, join
+
+DIR = (dirname(__file__) or '.')
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -19,5 +23,6 @@ setuptools.setup(
         "console_scripts": [
             "pangolin=pangolin.pangolin:main"
         ]
-    }
+    },
+    scripts=glob(join(DIR, 'scripts/*.py')),
 )


### PR DESCRIPTION
This allows build systems like [Pants](https://www.pantsbuild.org/docs/reference-pex_binary#codescriptcode) to more easily package this software and create executable binaries from its scripts.