### PR TITLE
Remove biopython references

### DIFF
--- a/PangolinColab.ipynb
+++ b/PangolinColab.ipynb
@@ -50,7 +50,7 @@
         "id": "NpEQ3rtI9BI6"
       },
       "source": [
-        "!pip install pyvcf gffutils biopython pandas pyfastx\n",
+        "!pip install pyvcf gffutils pandas pyfastx\n",
         "!git clone https://github.com/tkzeng/Pangolin.git\n",
         "%cd Pangolin\n",
         "!pip install .\n",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See below for information on usage and local installation.
 * Install other dependencies:
   ```
   conda install -c conda-forge pyvcf
-  pip install gffutils biopython pandas pyfastx
+  pip install gffutils pandas pyfastx
   ```
 * Install Pangolin:
   ```


### PR DESCRIPTION
The README and colab document refer to a need to install biopython, but I don't see that this package is used anywhere. This commit removes those references in the documentation so people will not think they need this extraneous dependency.